### PR TITLE
[WASM] Adjust DragCoordinates to apply motion incrementally

### DIFF
--- a/src/Sample/Sample.Shared/Tests/DragCoordinates_Tests.xaml
+++ b/src/Sample/Sample.Shared/Tests/DragCoordinates_Tests.xaml
@@ -13,6 +13,7 @@
 		<StackPanel VerticalAlignment="Bottom">
 			<TextBlock x:Name="borderPositionLeft" Text="{Binding (Canvas.Left), ElementName=myBorder}" />
 			<TextBlock x:Name="borderPositionTop" Text="{Binding (Canvas.Top), ElementName=myBorder}"/>
+			<TextBlock x:Name="movedCount" Text="0"/>
 		</StackPanel>
 		
 		<Canvas x:Name="rootCanvas" Width="500" Height="500">

--- a/src/Sample/Sample.Shared/Tests/DragCoordinates_Tests.xaml.cs
+++ b/src/Sample/Sample.Shared/Tests/DragCoordinates_Tests.xaml.cs
@@ -20,6 +20,8 @@ namespace Sample.Shared.Tests
 {
 	public sealed partial class DragCoordinates_Tests : UserControl
 	{
+		private int _movedCount;
+
 		public DragCoordinates_Tests()
 		{
 			this.InitializeComponent();
@@ -39,6 +41,8 @@ namespace Sample.Shared.Tests
 				{
 					Canvas.SetTop(myBorder, e.GetCurrentPoint(rootCanvas).Position.Y - startPos.Y);
 					Canvas.SetLeft(myBorder, e.GetCurrentPoint(rootCanvas).Position.X - startPos.X);
+					_movedCount++;
+					movedCount.Text = _movedCount.ToString();
 				}
 			};
 

--- a/src/Sample/Sample.UITests/DragCoordinates_Tests.cs
+++ b/src/Sample/Sample.UITests/DragCoordinates_Tests.cs
@@ -22,6 +22,8 @@ namespace Sample.UITests
 			Query topValue = q => q.Marked("borderPositionTop");
 			Query leftValue = q => q.Marked("borderPositionLeft");
 
+			Query movedCountValue = q => q.Marked("movedCount");
+
 			App.WaitForElement(testSelector);
 			App.Tap(testSelector);
 
@@ -49,6 +51,12 @@ namespace Sample.UITests
 
 			App.WaitForDependencyPropertyValue(topValue, "Text", "50");
 			App.WaitForDependencyPropertyValue(leftValue, "Text", "50");
+
+			var movedCountText = App.Query(q => movedCountValue(q).GetDependencyPropertyValue("Text").Value<string>()).First();
+
+			var movedCount = int.Parse(movedCountText);
+
+			Assert.Greater(movedCount, 1);
 		}
 	}
 }


### PR DESCRIPTION
Calling MoveByOffset 'in one hit' will not raise pointermove event, adjust to be closer to user behavior and Android/iOS test behavior.

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
