### PR TITLE
Rect Center were not properly implemented.

### DIFF
--- a/src/Uno.UITest.Helpers/Class1.cs
+++ b/src/Uno.UITest.Helpers/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace Uno.UITest.Helpers
-{
-	public class Class1
-	{
-	}
-}

--- a/src/Uno.UITest.Puppeteer/SeleniumAppRect.cs
+++ b/src/Uno.UITest.Puppeteer/SeleniumAppRect.cs
@@ -14,7 +14,9 @@ namespace Uno.UITest.Selenium
 		float IAppRect.Height => _source.Size.Height;
 		float IAppRect.X => _source.Location.X;
 		float IAppRect.Y => _source.Location.Y;
-		float IAppRect.CenterX => _source.Location.X + _source.Size.Width / 2;
-		float IAppRect.CenterY => _source.Location.Y + _source.Size.Height / 2;
+		float IAppRect.CenterX => _source.Location.X + (_source.Size.Width / 2);
+		float IAppRect.CenterY => _source.Location.Y + (_source.Size.Height / 2);
+		float IAppRect.Right => _source.Location.X + _source.Size.Width;
+		float IAppRect.Bottom => _source.Location.Y + _source.Size.Height;
 	}
 }

--- a/src/Uno.UITest.Xamarin/XamarinAppRect.cs
+++ b/src/Uno.UITest.Xamarin/XamarinAppRect.cs
@@ -16,5 +16,9 @@ namespace Uno.UITest.Xamarin
 		public float Y => _source.Y;
 		public float CenterX => _source.CenterX;
 		public float CenterY => _source.CenterY;
+
+		float IAppRect.Right => _source.X + _source.Width;
+
+		float IAppRect.Bottom => _source.Y + _source.Height;
 	}
 }

--- a/src/uno.uitest/IAppRect.cs
+++ b/src/uno.uitest/IAppRect.cs
@@ -13,5 +13,9 @@
 		float CenterX { get; }
 
 		float CenterY { get; }
+
+		float Right { get; }
+
+		float Bottom { get; }
 	}
 }


### PR DESCRIPTION
## Bugfix

IAppRectCenter were implemented like that: (once code decompiled)
``` csharp
float IAppRect.CenterX => (_source.Location.X + _source.Size.Width) / 2;
float IAppRect.CenterY => (_source.Location.Y + _source.Size.Height) / 2;
```

Right implementation:
``` csharp
float IAppRect.CenterX => _source.Location.X + (_source.Size.Width / 2);
float IAppRect.CenterY => _source.Location.Y + (_source.Size.Height / 2);
```

It's unclear why the priorities of operations were not applied on this.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
