### PR TITLE
Add the DetectDockerEnvironment and SeleniumArgument parameters

### DIFF
--- a/src/Uno.UITest.Puppeteer/ChromeAppConfigurator.cs
+++ b/src/Uno.UITest.Puppeteer/ChromeAppConfigurator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Uno.UITest.Selenium
 {
@@ -11,6 +12,8 @@ namespace Uno.UITest.Selenium
 		internal int InternalWindowWidth { get; private set; } = 1024;
 		internal int InternalWindowHeight { get; private set; } = 768;
 		internal string InternalBrowserBinaryPath { get; private set; }
+		internal List<string> InternalSeleniumArgument = new List<string>();
+		internal bool InternalDetectDockerEnvironment = true;
 
 		public ChromeAppConfigurator()
 		{
@@ -23,6 +26,17 @@ namespace Uno.UITest.Selenium
 		public ChromeAppConfigurator ScreenShotsPath(string path) { InternalScreenShotsPath = path; return this; }
 
 		public ChromeAppConfigurator BrowserBinaryPath(string path) { InternalBrowserBinaryPath = path; return this; }
+
+		/// <summary>
+		/// This parameters allows to provide a set of additional parameters to be provided to the WebDriver.
+		/// </summary>
+		public ChromeAppConfigurator SeleniumArgument(string argument) { InternalSeleniumArgument.Add(argument); return this; }
+
+
+		/// <summary>
+		/// Enables the detection of the docker environment to configure the WebDriver accordingly. Enabled by default.
+		/// </summary>
+		public ChromeAppConfigurator DetectDockerEnvironment(bool enabled) { InternalDetectDockerEnvironment = enabled; return this; }
 
 		/// <summary>
 		/// Runs the browser as headless. Defaults to true.

--- a/src/Uno.UITest.Puppeteer/SeleniumApp.cs
+++ b/src/Uno.UITest.Puppeteer/SeleniumApp.cs
@@ -23,6 +23,7 @@ namespace Uno.UITest.Selenium
 
 		public SeleniumApp(ChromeAppConfigurator config)
 		{
+			// --whitelisted-ips
 			var targetUri = GetEnvironmentVariable("UNO_UITEST_TARGETURI", config.SiteUri.OriginalString);
 			var driverPath = GetEnvironmentVariable("UNO_UITEST_DRIVERPATH_CHROME", config.ChromeDriverPath);
 			var screenShotPath = GetEnvironmentVariable("UNO_UITEST_SCREENSHOT_PATH", config.InternalScreenShotsPath);
@@ -37,6 +38,27 @@ namespace Uno.UITest.Selenium
 			}
 
 			options.AddArgument($"window-size={config.InternalWindowWidth}x{config.InternalWindowHeight}");
+
+			if(config.InternalDetectDockerEnvironment)
+			{
+				if(File.Exists("/.dockerenv"))
+				{
+					// When running under docker, ports bindings may not work properly
+					// as the current local host may not be detected properly by the web driver
+					// causing errors like this one:
+					//
+					// [SEVERE]: bind() returned an error, errno=99: Cannot assign requested address (99)
+					//
+					// When InternalDetectDockerEnvironment is set, tell the daemon to listen on
+					// all available interfaces
+					options.AddArguments("--whitelisted-ips");
+				}
+			}
+
+			foreach(var arg in config.InternalSeleniumArgument)
+			{
+				options.AddArguments(arg);
+			}
 
 			if(!string.IsNullOrEmpty(chromeBinPath))
 			{

--- a/src/Uno.UITest.Puppeteer/SeleniumApp.cs
+++ b/src/Uno.UITest.Puppeteer/SeleniumApp.cs
@@ -51,6 +51,7 @@ namespace Uno.UITest.Selenium
 					//
 					// When InternalDetectDockerEnvironment is set, tell the daemon to listen on
 					// all available interfaces
+					Console.WriteLine($"Detected docker environment, adding whitelisted-ips");
 					options.AddArguments("--whitelisted-ips");
 				}
 			}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix and Feature

## What is the current behavior?
WebAssembly testing may fail with:
```
[SEVERE]: bind() returned an error, errno=99: Cannot assign requested address (99)
```

## What is the new behavior?
This is caused by docker configurations and WebDriver discovery. Uno.UITest now exposes a `DetectDockerEnvironment` configuration to work around this issue.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
