### PR TITLE
Added support for `WaitForNoElement()` on browser

### DIFF
--- a/src/Sample/Sample.Shared/Tests/CheckBox_Tests.xaml
+++ b/src/Sample/Sample.Shared/Tests/CheckBox_Tests.xaml
@@ -1,16 +1,18 @@
 ﻿<UserControl
-    x:Class="Sample.Shared.Tests.CheckBox_Tests"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Sample.Shared.Tests"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    d:DesignHeight="300"
-    d:DesignWidth="400">
+	x:Class="Sample.Shared.Tests.CheckBox_Tests"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Sample.Shared.Tests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
 
-    <StackPanel>
+	<StackPanel>
 		<CheckBox x:Name="cb1" Content="Test 1"/>
 		<CheckBox x:Name="cb2" Content="Test 2"/>
+		<Border x:Name="checked1" Width="200" Height="30" />
+		<Border x:Name="checked2" Width="200" Height="30" />
 	</StackPanel>
 </UserControl>

--- a/src/Sample/Sample.Shared/Tests/CheckBox_Tests.xaml.cs
+++ b/src/Sample/Sample.Shared/Tests/CheckBox_Tests.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -12,6 +13,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using Windows.UI.Xaml.Shapes;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
@@ -22,6 +24,16 @@ namespace Sample.Shared.Tests
 		public CheckBox_Tests()
 		{
 			this.InitializeComponent();
+
+			cb1.Checked += (snd, evt) =>
+				checked1.Child = new Rectangle {Name = "rect1", Fill = new SolidColorBrush(Colors.Red)};
+			cb1.Unchecked += (snd, evt) =>
+				checked1.Child = null;
+
+			cb2.Checked += (snd, evt) =>
+				checked2.Child = new Rectangle {Name = "rect2", Fill = new SolidColorBrush(Colors.Blue)};
+			cb2.Unchecked += (snd, evt) =>
+				checked2.Child = null;
 		}
 	}
 }

--- a/src/Sample/Sample.UITests/CheckBox_Tests.cs
+++ b/src/Sample/Sample.UITests/CheckBox_Tests.cs
@@ -29,15 +29,27 @@ namespace Sample.UITests
 			var value2 = App.Query(q => cb2(q).GetDependencyPropertyValue("IsChecked").Value<bool>()).First();
 			Assert.IsFalse(value2);
 
+			App.WaitForNoElement("rect1");
+			App.WaitForNoElement("rect2");
+
 			App.Tap(cb1);
 
 			var value3 = App.Query(q => cb1(q).GetDependencyPropertyValue("IsChecked").Value<bool>()).First();
 			Assert.IsTrue(value3);
 
+			App.WaitForElement("rect1");
+
 			App.Tap(cb2);
 
 			var value4 = App.Query(q => cb1(q).GetDependencyPropertyValue("IsChecked").Value<bool>()).First();
 			Assert.IsTrue(value4);
+
+			App.WaitForElement("rect2");
+
+			App.Tap(cb1);
+			App.Tap(cb2);
+			App.WaitForNoElement("rect1");
+			App.WaitForNoElement("rect2");
 		}
 	}
 }

--- a/src/Uno.UITest.Puppeteer/SeleniumApp.cs
+++ b/src/Uno.UITest.Puppeteer/SeleniumApp.cs
@@ -313,15 +313,15 @@ namespace Uno.UITest.Selenium
 			}
 		}
 
-        void IApp.TapCoordinates(float x, float y)
-        {
-            PerformActions(a => a
+		void IApp.TapCoordinates(float x, float y)
+		{
+			PerformActions(a => a
 				.MoveToElement(_driver.FindElementByTagName("body"), 0, 0)
 				.MoveByOffset((int)x, (int)y)
 				.Click());
-        }
+		}
 
-        void IApp.TouchAndHold(Func<IAppQuery, IAppQuery> query) => throw new NotSupportedException();
+		void IApp.TouchAndHold(Func<IAppQuery, IAppQuery> query) => throw new NotSupportedException();
 		void IApp.TouchAndHold(string marked) => throw new NotSupportedException();
 		void IApp.TouchAndHoldCoordinates(float x, float y) => throw new NotSupportedException();
 		void IApp.WaitFor(Func<bool> predicate, string timeoutMessage, TimeSpan? timeout, TimeSpan? retryFrequency, TimeSpan? postTimeout)
@@ -369,7 +369,7 @@ namespace Uno.UITest.Selenium
 			{
 				var results = (this as IApp).Query(query);
 
-				if(results.Count() != 0)
+				if(results.Any())
 				{
 					return results;
 				}
@@ -381,10 +381,35 @@ namespace Uno.UITest.Selenium
 		}
 
 		void IApp.WaitForNoElement(Func<IAppQuery, IAppQuery> query, string timeoutMessage, TimeSpan? timeout, TimeSpan? retryFrequency, TimeSpan? postTimeout)
-			=> throw new NotSupportedException();
+		{
+			var sw = Stopwatch.StartNew();
+			timeout = timeout ?? TimeSpan.MaxValue;
+			retryFrequency = retryFrequency ?? DefaultRetry;
+			timeoutMessage = timeoutMessage ?? "Timed out waiting for element...";
 
-		void IApp.WaitForNoElement(string marked, string timeoutMessage, TimeSpan? timeout, TimeSpan? retryFrequency, TimeSpan? postTimeout)
-			=> throw new NotSupportedException();
+			while(sw.Elapsed < timeout)
+			{
+				var results = (this as IApp).Query(query);
+
+				if(!results.Any())
+				{
+					return;
+				}
+
+				Thread.Sleep(retryFrequency.Value);
+			}
+
+			throw new TimeoutException(timeoutMessage);
+		}
+
+		void IApp.WaitForNoElement(string marked, string timeoutMessage, TimeSpan? timeout, TimeSpan? retryFrequency,
+			TimeSpan? postTimeout)
+			=> (this as IApp).WaitForNoElement(
+				query: q => q.Marked(marked),
+				timeoutMessage: timeoutMessage,
+				timeout: timeout,
+				retryFrequency: retryFrequency,
+				postTimeout: postTimeout);
 
 		void IApp.WaitForNoElement(
 			Func<IAppQuery, IAppWebQuery> query,


### PR DESCRIPTION
##  Feature

## What is the new behavior?
You can now use the method `_app.WaitForNoElement()` on a wasm target.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
