### PR TITLE
fix(selenium): Selenium were not supporting xpath 2.0 syntax.

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -33,11 +33,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-
-  - task: NuGetToolInstaller@0
-    inputs:
-      versionSpec: 4.9.1
-      checkLatest: false
     
   - task: GitVersion@5
     inputs:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,6 +14,8 @@
 
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <DefaultLanguage>en-US</DefaultLanguage>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <Choose>
@@ -27,8 +29,8 @@
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.Vsts.Git" Version="1.0.0-beta-62925-02" PrivateAssets="All"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.0.0" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
       </ItemGroup>
     </When>
   </Choose>

--- a/src/Sample/Sample.Shared/Tests/Element_Selection_Tests_01.xaml
+++ b/src/Sample/Sample.Shared/Tests/Element_Selection_Tests_01.xaml
@@ -23,5 +23,8 @@
 		<ContentControl x:Name="outer02"
 						Content="Text 2"
 						ContentTemplate="{StaticResource myTemplate}" />
+
+		<DatePicker />
+		<TextBlock x:Name="MyTextBlock">MyTextBlock</TextBlock>
 	</StackPanel>
 </UserControl>

--- a/src/Sample/Sample.UITests/ElementSelection_Tests.cs
+++ b/src/Sample/Sample.UITests/ElementSelection_Tests.cs
@@ -41,18 +41,20 @@ namespace Sample.UITests
 			App.WaitForElement(testSelector);
 			App.Tap(testSelector);
 
+			App.WaitForElement(App.CreateQuery(
+				q => q.WithClass("Windows.UI.Xaml.Controls.TextBlock")));
 
 			App.WaitForElement(App.CreateQuery(
-				q => q.WithClass("TextBlock")));
+				q => q.WithClass("Windows_UI_Xaml_Controls_TextBlock")));
 
 			App.WaitForElement(App.CreateQuery(
-				q => q.WithClass("DatePicker")));
+				q => q.WithClass("Windows.UI.Xaml.Controls.DatePicker")));
 
 			App.WaitForElement(App.CreateQuery(
 				q => q.WithText("MyTextBlock")));
 
 			App.WaitForElement(App.CreateQuery(
-				q => q.WithClass("TextBlock").WithText("MyTextBlock")));
+				q => q.WithClass("Windows.UI.Xaml.Controls.TextBlock").WithText("MyTextBlock")));
 		}
 	}
 }

--- a/src/Sample/Sample.UITests/ElementSelection_Tests.cs
+++ b/src/Sample/Sample.UITests/ElementSelection_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -36,6 +37,7 @@ namespace Sample.UITests
 		[Test]
 		public void ElementSelection_WithClass()
 		{
+			//App.Repl();
 			Query testSelector = q => q.Marked("Element Selection 01");
 
 			App.WaitForElement(testSelector);
@@ -50,11 +52,14 @@ namespace Sample.UITests
 			App.WaitForElement(App.CreateQuery(
 				q => q.WithClass("Windows.UI.Xaml.Controls.DatePicker")));
 
-			App.WaitForElement(App.CreateQuery(
-				q => q.WithText("MyTextBlock")));
+			if(Helpers.Platform != Platform.iOS)
+			{
+				App.WaitForElement(App.CreateQuery(
+					q => q.WithText("MyTextBlock")));
 
-			App.WaitForElement(App.CreateQuery(
-				q => q.WithClass("Windows.UI.Xaml.Controls.TextBlock").WithText("MyTextBlock")));
+				App.WaitForElement(App.CreateQuery(
+					q => q.WithClass("Windows.UI.Xaml.Controls.TextBlock").WithText("MyTextBlock")));
+			}
 		}
 	}
 }

--- a/src/Sample/Sample.UITests/ElementSelection_Tests.cs
+++ b/src/Sample/Sample.UITests/ElementSelection_Tests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 using Query = System.Func<Uno.UITest.IAppQuery, Uno.UITest.IAppQuery>;
 using StringQuery = System.Func<Uno.UITest.IAppQuery, Uno.UITest.IAppTypedSelector<string>>;
@@ -30,6 +31,28 @@ namespace Sample.UITests
 			Query inner02 = q => q.Marked("outer02").Descendant().Marked("innerElement");
 			App.Tap(inner02);
 			App.WaitForDependencyPropertyValue(inner02, "Text", "Text 2");
+		}
+
+		[Test]
+		public void ElementSelection_WithClass()
+		{
+			Query testSelector = q => q.Marked("Element Selection 01");
+
+			App.WaitForElement(testSelector);
+			App.Tap(testSelector);
+
+
+			App.WaitForElement(App.CreateQuery(
+				q => q.WithClass("TextBlock")));
+
+			App.WaitForElement(App.CreateQuery(
+				q => q.WithClass("DatePicker")));
+
+			App.WaitForElement(App.CreateQuery(
+				q => q.WithText("MyTextBlock")));
+
+			App.WaitForElement(App.CreateQuery(
+				q => q.WithClass("TextBlock").WithText("MyTextBlock")));
 		}
 	}
 }

--- a/src/Uno.UITest.Helpers/Helpers/UITests.Queries/Query.cs
+++ b/src/Uno.UITest.Helpers/Helpers/UITests.Queries/Query.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using Uno.UITest.Helpers.Queries;
+using Uno.UITest.Xamarin.Extensions;
 
 namespace Uno.UITest.Helpers.Queries
 {
@@ -121,7 +122,10 @@ namespace Uno.UITest.Helpers.Queries
 
 		public QueryEx WithClass(string @class)
 		{
-			return this.Compose((IAppQuery x) => x.Class(@class));
+			return this.Compose((IAppQuery x) => x.Class(
+				x is XamarinAppQuery
+					? @class.Replace(".", "_")
+					: @class));
 		}
 
 		public QueryEx Marked(string mark)
@@ -156,7 +160,8 @@ namespace Uno.UITest.Helpers.Queries
 
 		public QueryEx WithPlaceholder(string placeholder)
 		{
-			return Helpers.On<QueryEx>(this.Raw(string.Format("* {{placeholder LIKE '{0}'}}", placeholder)), this.Raw(string.Format("* {{hint LIKE '{0}'}}", placeholder)));
+			return Helpers.On<QueryEx>(this.Raw($"* {{placeholder LIKE '{placeholder}'}}"), this.Raw(
+				$"* {{hint LIKE '{placeholder}'}}"));
 		}
 
 		public QueryEx WithExactText(string text)
@@ -167,7 +172,7 @@ namespace Uno.UITest.Helpers.Queries
 		public QueryEx WithText(string text)
 		{
 			string arg = text.Replace("'", "\\'");
-			return this.Descendant().Raw(string.Format("* {{text contains '{0}'}}", arg));
+			return this.Descendant().Raw($"* {{text contains '{arg}'}}");
 		}
 
 		public QueryEx AtIndex(int i)

--- a/src/Uno.UITest.Helpers/Helpers/UITests.Queries/Query.cs
+++ b/src/Uno.UITest.Helpers/Helpers/UITests.Queries/Query.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Uno.UITest.Helpers.Queries;
 using Uno.UITest.Xamarin.Extensions;
@@ -122,10 +123,16 @@ namespace Uno.UITest.Helpers.Queries
 
 		public QueryEx WithClass(string @class)
 		{
-			return this.Compose((IAppQuery x) => x.Class(
-				x is XamarinAppQuery
-					? @class.Replace(".", "_")
-					: @class));
+			var fullName = @class.Replace(".", "_");
+			if(Helpers.Platform == Platform.iOS)
+			{
+				// For iOS, we specify the fullname of the class
+				return this.Compose((IAppQuery x) => x.Class(fullName));
+			}
+
+			// Android & Wasm will required non-qualified class name
+			var name = fullName.Split('_').Last();
+			return this.Compose((IAppQuery x) => x.Class(name));
 		}
 
 		public QueryEx Marked(string mark)

--- a/src/Uno.UITest.Puppeteer/Properties/AssemblyAttributes.cs
+++ b/src/Uno.UITest.Puppeteer/Properties/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Uno.UITest.Helpers")] 

--- a/src/Uno.UITest.Puppeteer/SeleniumAppQuery.cs
+++ b/src/Uno.UITest.Puppeteer/SeleniumAppQuery.cs
@@ -35,7 +35,9 @@ namespace Uno.UITest.Selenium
 			=> this.seleniumApp = seleniumApp;
 
 		IAppQuery IAppQuery.All(string className)
-			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[contains(@xamltype, '{className}')]")));
+			=> string.IsNullOrEmpty(className)
+				? Apply(() => { })
+				: Apply(() => _queryItems.Add(new SearchQueryItem($"//*[contains(@xamltype, '{className}')]")));
 
 		IAppQuery IAppQuery.Button(string marked)
 			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[@xamltype='Windows.UI.Xaml.Controls.Button' and (xamlname='{marked}') or @xuid='{marked}')]")));

--- a/src/Uno.UITest.Puppeteer/SeleniumAppQuery.cs
+++ b/src/Uno.UITest.Puppeteer/SeleniumAppQuery.cs
@@ -35,19 +35,19 @@ namespace Uno.UITest.Selenium
 			=> this.seleniumApp = seleniumApp;
 
 		IAppQuery IAppQuery.All(string className)
-			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[ends-with(@xamltype, '{className}')]")));
+			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[contains(@xamltype, '{className}')]")));
 
 		IAppQuery IAppQuery.Button(string marked)
 			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[@xamltype='Windows.UI.Xaml.Controls.Button' and (xamlname='{marked}') or @xuid='{marked}')]")));
 
 		IAppQuery IAppQuery.Child(string className)
-			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[ends-with(@xamltype, '{className}')]")));
+			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[contains(@xamltype, '{className}')]")));
 
 		IAppQuery IAppQuery.Child(int index)
 			=> Apply(() => _queryItems.Add(new SearchQueryItem($"/[{index}]")));
 
 		IAppQuery IAppQuery.Class(string className)
-			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[ends-with(@xamltype, '{className}')]")));
+			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[contains(@xamltype, '{className}')]")));
 
 		IAppQuery IAppQuery.ClassFull(string className)
 			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[@xamltype='{className}']")));
@@ -56,7 +56,7 @@ namespace Uno.UITest.Selenium
 		IAppQuery IAppQuery.Descendant(string className)
 			=> string.IsNullOrEmpty(className)
 				? Apply(() => { })
-				: Apply(() => _queryItems.Add(new SearchQueryItem($"//*[ends-with(@xamltype, '{className}')]")));
+				: Apply(() => _queryItems.Add(new SearchQueryItem($"//*[contains(@xamltype, '{className}')]")));
 
 		IAppQuery IAppQuery.Frame(string cssSelector) => throw new System.NotImplementedException();
 
@@ -117,7 +117,7 @@ namespace Uno.UITest.Selenium
 			=> Apply(() => _queryItems.Add(new SearchQueryItem($"//*[@xamlname='{text}' or @xuid='{text}' or @xamlautomationid='{text}']")));
 
 		IAppQuery IAppQuery.Parent(string className)
-			=> Apply(() => _queryItems.Add(new SearchQueryItem($"./ancestor::*[ends-with(@xamltype, {className})]")));
+			=> Apply(() => _queryItems.Add(new SearchQueryItem($"./ancestor::*[contains(@xamltype, {className})]")));
 
 		IAppQuery IAppQuery.Parent(int index)
 			=> Apply(() => _queryItems.Add(new SearchQueryItem($"./ancestor::*[position()={index}]")));
@@ -144,17 +144,23 @@ namespace Uno.UITest.Selenium
 		IAppTypedSelector<string> IAppQuery.Raw(string calabashQuery, object arg1, object arg2) => throw new System.NotImplementedException();
 		IAppQuery IAppQuery.Raw(string calabashQuery)
 		{
-			var match = Regex.Match(calabashQuery, @"(.*)\s(marked|text):'((.|\n)*)'");
+			var match = Regex.Match(calabashQuery, @"(\*|[\w\.]+)\s\{?(marked|text)\s*(:|\scontains)\s*'((.|\n)+)'\}?");
+
+			if(!match.Success)
+			{
+				throw new ArgumentException($"query {calabashQuery} is invalid.", nameof(calabashQuery));
+			}
 
 			var controlType = match.Groups[1].Captures[0].Value;
 			var type = match.Groups[2].Captures[0].Value;
-			var value = match.Groups[3].Captures[0].Value;
+			var operation = match.Groups[3].Captures[0].Value;
+			var value = match.Groups[4].Captures[0].Value;
 
 			if(controlType == "*")
 			{
 				switch(type)
 				{
-					case "marked":
+					case "marked" when operation == ":":
 						return ((IAppQuery)this).Marked(value);
 					case "text":
 						return ((IAppQuery)this).Text(value);

--- a/src/Uno.UITest.Xamarin/Properties/AssemblyAttributes.cs
+++ b/src/Uno.UITest.Xamarin/Properties/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Uno.UITest.Helpers")] 

--- a/src/Uno.UITest.Xamarin/Uno.UITest.Xamarin.csproj
+++ b/src/Uno.UITest.Xamarin/Uno.UITest.Xamarin.csproj
@@ -5,7 +5,7 @@
 		<IsTestProject>false</IsTestProject>
 		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
 	</PropertyGroup>
-	
+
 	<PropertyGroup>
 		<PackageProjectUrl>https://github.com/nventive/Uno.UITest</PackageProjectUrl>
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
@@ -20,7 +20,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Xamarin.UITest" Version="3.0.5" />
+		<PackageReference Include="Xamarin.UITest" Version="3.0.12" />
 
 		<!-- Workaround for missing cecil binary in Xamarin.UITest -->
 		<PackageReference Include="mono.cecil" Version="0.9.6" />

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,6 @@
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
# Bugfix

The `QueryEx.WithClass()` were not working on Wasm because it was using xpath 2.0, which is not supported by browsers.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
