### PR TITLE
docs: list only supported VS versions in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -33,7 +33,7 @@ For bug reports please provide a *MINIMAL REPRO PROJECT* and the *STEPS TO REPRO
 Package Version(s): 
 
 Visual Studio
-- [ ] 2017 (version: )
-- [ ] 2017 Preview (version: )
+- [ ] 2019 (version: )
+- [ ] 2019 Preview (version: )
 - [ ] for Mac (version: )
 ```


### PR DESCRIPTION
X-Ref: https://github.com/unoplatform/uno/blob/master/doc/articles/get-started.md#prerequisites

GitHub Issue (If applicable): # n/a
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
- Other... Please describe: nit-picky fix to the the issue template


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the issue template references VS2017 (which is no longer supported) and does not include VS2019 (which is supported)

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Reference VS2019 instead of VS2017

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
