### PR TITLE
fix: Add fallback behavior for chrome exe detection

### DIFF
--- a/src/Uno.UITest.Puppeteer/SeleniumApp.cs
+++ b/src/Uno.UITest.Puppeteer/SeleniumApp.cs
@@ -87,6 +87,14 @@ namespace Uno.UITest.Selenium
 			if(Environment.OSVersion.Platform == PlatformID.Win32NT)
 			{
 				var chromePath = $@"{Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}\Google\Chrome\Application\chrome.exe";
+				// Chrome might be installed in C:\Program Files\Google...
+				// If file doesn't exist, check there.
+				if(!File.Exists(chromePath))
+				{
+					// Using environment variable here since EnvironMent.SpecialFolder.ProgramFiles resolves to the X86
+					// variant depending on the executable architecture. The path variable always evaluates to the correct path though.
+					chromePath = $@"{Environment.GetEnvironmentVariable("ProgramW6432")}\Google\Chrome\Application\chrome.exe";
+				}
 				chromePath = chromePath.Replace("\\", "\\\\");
 
 				var process = new Process();


### PR DESCRIPTION
GitHub Issue (If applicable): #51
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If chrome is not installed in "Program Files x86" but in "Program Files", test execution fails.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Now, if one of them fails, the other path will be checked too.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue: Closes #51 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
