### PR TITLE
fix(Scrolling): Fix null ref in scrolling logic

### DIFF
--- a/src/Uno.UITest.Xamarin/XamarinApp.cs
+++ b/src/Uno.UITest.Xamarin/XamarinApp.cs
@@ -266,13 +266,13 @@ namespace Uno.UITest.Xamarin
 			=> _source.ScrollDown(withinMarked, strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia);
 
 		public void ScrollDown(Func<IAppQuery, IAppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
-			=> _source.ScrollDown(q => withinQuery(q.AsGenericAppQuery()).ToXamarinQuery(), strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia);
+			=> _source.ScrollDown(q => withinQuery?.Invoke(q.AsGenericAppQuery()).ToXamarinQuery(), strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia);
 
 		public void ScrollDownTo(Func<IAppQuery, IAppWebQuery> toQuery, Func<IAppQuery, IAppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
-			=> _source.ScrollDownTo(q => toQuery(q.AsGenericAppQuery()).ToXamarinQuery(), q => withinQuery(q.AsGenericAppQuery()).ToXamarinQuery(), strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia, timeout);
+			=> _source.ScrollDownTo(q => toQuery(q.AsGenericAppQuery()).ToXamarinQuery(), q => withinQuery?.Invoke(q.AsGenericAppQuery()).ToXamarinQuery(), strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia, timeout);
 
 		public void ScrollDownTo(Func<IAppQuery, IAppQuery> toQuery, Func<IAppQuery, IAppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
-			=> _source.ScrollDownTo(q => toQuery(q.AsGenericAppQuery()).ToXamarinQuery(), q => withinQuery(q.AsGenericAppQuery()).ToXamarinQuery(), strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia, timeout);
+			=> _source.ScrollDownTo(q => toQuery(q.AsGenericAppQuery()).ToXamarinQuery(), q => withinQuery?.Invoke(q.AsGenericAppQuery()).ToXamarinQuery(), strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia, timeout);
 
 		public void ScrollDownTo(Func<IAppQuery, IAppWebQuery> toQuery, string withinMarked, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
 			=> _source.ScrollDownTo(q => toQuery(q.AsGenericAppQuery()).ToXamarinQuery(), withinMarked, strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia, timeout);
@@ -290,10 +290,10 @@ namespace Uno.UITest.Xamarin
 			=> _source.ScrollUp(withinMarked, strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia);
 
 		public void ScrollUpTo(Func<IAppQuery, IAppQuery> toQuery, Func<IAppQuery, IAppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
-			=> _source.ScrollUpTo(q => toQuery(q.AsGenericAppQuery()).ToXamarinQuery(), q => withinQuery(q.AsGenericAppQuery()).ToXamarinQuery(), strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia, timeout);
+			=> _source.ScrollUpTo(q => toQuery(q.AsGenericAppQuery()).ToXamarinQuery(), q => withinQuery?.Invoke(q.AsGenericAppQuery()).ToXamarinQuery(), strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia, timeout);
 
 		public void ScrollUpTo(Func<IAppQuery, IAppWebQuery> toQuery, Func<IAppQuery, IAppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
-			=> _source.ScrollUpTo(q => toQuery(q.AsGenericAppQuery()).ToXamarinQuery(), q => withinQuery(q.AsGenericAppQuery()).ToXamarinQuery(), strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia, timeout);
+			=> _source.ScrollUpTo(q => toQuery(q.AsGenericAppQuery()).ToXamarinQuery(), q => withinQuery?.Invoke(q.AsGenericAppQuery()).ToXamarinQuery(), strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia, timeout);
 
 		public void ScrollUpTo(Func<IAppQuery, IAppWebQuery> toQuery, string withinMarked, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
 			=> _source.ScrollUpTo(q => toQuery(q.AsGenericAppQuery()).ToXamarinQuery(), withinMarked, strategy.ToXamarinScrollStrategy(), swipePercentage, swipeSpeed, withInertia, timeout);


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?
- Bugfix


## What is the current behavior?
Null ref when using the default value of `null` for `withinQuery` for Scroll methods

## What is the new behavior?
No exception

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
