### PR TITLE
Add support for net6.0

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,6 +47,12 @@ jobs:
     displayName: Use GitVersion
 
   - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK 5.0.101'
+    inputs:
+      packageType: sdk
+      version: 5.0.101
+
+  - task: UseDotNet@2
     displayName: 'Use .NET Core SDK 6.0.401'
     retryCountOnTaskFailure: 3
     inputs:
@@ -104,6 +110,13 @@ jobs:
     clean: true
 
   - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK 5.0.101'
+    inputs:
+      packageType: sdk
+      version: 5.0.101
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK 6.0.401'
     inputs:
       packageType: sdk
       version: 6.0.401

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -7,7 +7,7 @@ trigger:
       - stable
       - release/stable/*
 
-pr: 
+pr:
   branches:
     include:
       - master
@@ -26,14 +26,14 @@ jobs:
 
   pool:
     vmImage: 'windows-2022'
-    
+
   variables:
     NUGET_PACKAGES: $(Agent.WorkFolder)\.nuget
 
   steps:
   - checkout: self
     clean: true
-    
+
   - task: gitversion/setup@0
     retryCountOnTaskFailure: 3
     inputs:
@@ -47,11 +47,11 @@ jobs:
     displayName: Use GitVersion
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 5.0.400'
+    displayName: 'Use .NET Core SDK 6.0.401'
     retryCountOnTaskFailure: 3
     inputs:
       packageType: sdk
-      version: 5.0.400
+      version: 6.0.401
 
   - task: MSBuild@1
     inputs:
@@ -106,7 +106,7 @@ jobs:
   - task: UseDotNet@2
     inputs:
       packageType: sdk
-      version: 5.0.101
+      version: 6.0.401
 
   - bash: |
       chmod +x build/wasm-uitest-run.sh
@@ -188,10 +188,10 @@ jobs:
 
   - bash: /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_12_18"
     displayName: Select Xamarin Version
-    
+
   - bash: /bin/bash -c "echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${XCODE_ROOT};sudo xcode-select --switch ${XCODE_ROOT}/Contents/Developer"
     displayName: Select Xcode
-    
+
   - bash: |
       chmod +x $(build.sourcesdirectory)/build/ios-uitest-run.sh
       $(build.sourcesdirectory)/build/ios-uitest-run.sh

--- a/build/wasm-uitest-run.sh
+++ b/build/wasm-uitest-run.sh
@@ -7,7 +7,7 @@ export UNO_UITEST_SCREENSHOT_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/wa
 export UNO_UITEST_PROJECT=$BUILD_SOURCESDIRECTORY/src/Sample/Sample.UITests/Sample.UITests.csproj
 export UNO_UITEST_BINARY=$BUILD_SOURCESDIRECTORY/src/Sample/Sample.UITests/bin/Release/net47/Sample.UITests.dll
 export UNO_UITEST_WASM_PROJECT=$BUILD_SOURCESDIRECTORY/src/Sample/Sample.Wasm/Sample.Wasm.csproj
-export UNO_UITEST_WASM_OUTPUT_PATH=$BUILD_SOURCESDIRECTORY/src/Sample/Sample.Wasm/bin/Release/net5.0/dist/
+export UNO_UITEST_WASM_OUTPUT_PATH=$BUILD_SOURCESDIRECTORY/src/Sample/Sample.Wasm/bin/Release/net6.0/dist/
 
 ## Less commonly modified variables
 export UNO_UITEST_TARGETURI=http://localhost:5000

--- a/src/Sample/Sample.UITests/Sample.UITests.csproj
+++ b/src/Sample/Sample.UITests/Sample.UITests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net47</TargetFramework>
@@ -6,8 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>

--- a/src/Sample/Sample.UWP/Sample.UWP.csproj
+++ b/src/Sample/Sample.UWP/Sample.UWP.csproj
@@ -21,7 +21,7 @@
     <AssemblyName>Sample</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/Sample/Sample.Wasm/Sample.Wasm.csproj
+++ b/src/Sample/Sample.Wasm/Sample.Wasm.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <WasmHead>true</WasmHead>
     <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
     <NoWarn>NU1701</NoWarn>

--- a/src/Sample/Sample.Wasm/Sample.Wasm.csproj
+++ b/src/Sample/Sample.Wasm/Sample.Wasm.csproj
@@ -6,12 +6,12 @@
     <WasmHead>true</WasmHead>
     <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
     <NoWarn>NU1701</NoWarn>
-		<UnoUIUseRoslynSourceGenerators>true</UnoUIUseRoslynSourceGenerators>
-	</PropertyGroup>
-	<PropertyGroup>
-		<IsUiAutomationMappingEnabled>true</IsUiAutomationMappingEnabled>
-	</PropertyGroup>
-	<ItemGroup>
+    <UnoUIUseRoslynSourceGenerators>true</UnoUIUseRoslynSourceGenerators>
+  </PropertyGroup>
+  <PropertyGroup>
+    <IsUiAutomationMappingEnabled>true</IsUiAutomationMappingEnabled>
+  </PropertyGroup>
+  <ItemGroup>
     <Content Include="..\Sample.UWP\Assets\*.png" Link="Assets\%(FileName)%(Extension)" />
     <Content Include="Fonts\winjs-symbols.woff2" />
   </ItemGroup>
@@ -23,10 +23,10 @@
     <LinkerDescriptor Include="LinkerConfig.xml" />
   </ItemGroup>
   <ItemGroup>
-    <!-- 
+    <!--
     This item group is required by the project templace because of the
     new SDK-Style project, otherwise some files are not aded automatically.
-    
+
     You can safely remove this ItemGroup completely.
     -->
     <Compile Remove="Program.cs" />
@@ -35,9 +35,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.UI.WebAssembly" Version="3.7.6" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="2.1.0" />
-		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="2.1.0" />
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.1" />
-	</ItemGroup>
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.20" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.20" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.1" />
+  </ItemGroup>
   <Import Project="..\Sample.Shared\Sample.Shared.projitems" Label="Shared" Condition="Exists('..\Sample.Shared\Sample.Shared.projitems')" />
 </Project>

--- a/src/Sample/Sample.iOS/Sample.iOS.csproj
+++ b/src/Sample/Sample.iOS/Sample.iOS.csproj
@@ -120,7 +120,7 @@
   <ItemGroup>
     <PackageReference Include="Uno.UI" Version="3.7.6" />
     <PackageReference Include="Xamarin.TestCloud.Agent">
-      <Version>0.22.1</Version>
+      <Version>0.23.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Uno.UITest.Helpers/Uno.UITest.Helpers.csproj
+++ b/src/Uno.UITest.Helpers/Uno.UITest.Helpers.csproj
@@ -1,27 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net47</TargetFramework>
+		<TargetFrameworks>net47;net6.0</TargetFrameworks>
 		<IsTestProject>false</IsTestProject>
 		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
 	</PropertyGroup>
-	
+
 	<PropertyGroup>
 		<PackageProjectUrl>https://github.com/nventive/Uno.UITest</PackageProjectUrl>
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
 		<Description>
 			This package provides a set of high level helpers for the Uno.UITest framework.
-			
+
 			This framework can be used to test Uno PlatformWebAssembly apps through the use
 			of Selenuim, Xamarin.iOS and Xamarin.Android applications through Xamarin.UITest
 			and Microsoft AppCenter.
 		</Description>
 		<Copyright>Copyright (C) 2015-2019 nventive inc. - all rights reserved</Copyright>
 	</PropertyGroup>
-	
+
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
 		<PackageReference Include="NUnit" Version="3.13.0" />
 	</ItemGroup>
 

--- a/src/Uno.UITest.Puppeteer/Uno.UITest.Selenium.csproj
+++ b/src/Uno.UITest.Puppeteer/Uno.UITest.Selenium.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net47</TargetFramework>
+		<TargetFrameworks>net47;net6.0</TargetFrameworks>
 		<IsTestProject>false</IsTestProject>
 		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
 		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
-	
+
 	<PropertyGroup>
 		<PackageProjectUrl>https://github.com/nventive/Uno.UITest</PackageProjectUrl>
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Selenium.WebDriver" Version="4.0.0-beta2" />
+		<PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UITest.Xamarin/Uno.UITest.Xamarin.csproj
+++ b/src/Uno.UITest.Xamarin/Uno.UITest.Xamarin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net47</TargetFramework>
+		<TargetFrameworks>net47;net6.0</TargetFrameworks>
 		<IsTestProject>false</IsTestProject>
 		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
 	</PropertyGroup>
@@ -20,10 +20,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Xamarin.UITest" Version="3.2.8" />
+		<PackageReference Include="Xamarin.UITest" Version="4.1.2" />
 
 		<!-- Workaround for missing cecil binary in Xamarin.UITest -->
-		<PackageReference Include="mono.cecil" Version="0.9.6" />
+		<PackageReference Include="mono.cecil" Version="0.11.4" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #

- n/a

## PR Type
What kind of change does this PR introduce?

-Feature

## What is the current behavior?

Libraries only target net47

## What is the new behavior?

- Libraries now are multi-targeted with net6.0 support as well
- Updates Selenium to latest stable with updates for API breaks
- Updates Xamarin.UITest / Mono Cecil to latest
- Drops direct Newtonsoft.Json reference as this comes through transitively