### PR TITLE
FIX : obsolete Assert methods 

### DIFF
--- a/doc/using-uno-uitest.md
+++ b/doc/using-uno-uitest.md
@@ -83,12 +83,12 @@ The following target platforms are not yet supported:
 			App.WaitForElement(cb1);
 
 			var value1 = App.Query(q => cb1(q).GetDependencyPropertyValue("IsChecked").Value<bool>()).First();
-			Assert.IsFalse(value1);
+			Assert.That(!value1);
 
 			App.Tap(cb1);
 
 			var value2 = App.Query(q => cb1(q).GetDependencyPropertyValue("IsChecked").Value<bool>()).First();
-			Assert.IsTrue(value2);
+			Assert.That(value2);
 		}
 	}
 	```


### PR DESCRIPTION
Replaced usages of obsolete `.True()` and `.False()` methods from `NUnit.Assert` (NUnit 4.x) with `.That()` method.

Example unit test source code does not work with version of NUnit (4.x) that is referenced when creating new Uno.UITest via `dotnet new unoapp-uitest`

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
 - Documentation content changes 
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Example unit test source code _does not_ work with version of NUnit (4.x) that is referenced when creating new Uno.UITest via `dotnet new unoapp-uitest`


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Example unit test source code _does_ work with version of NUnit (4.x) that is referenced when creating new Uno.UITest via `dotnet new unoapp-uitest`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ n/a ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ x ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
