### PR TITLE
fix: update msedge driver download URLs

### DIFF
--- a/src/Uno.UITest.Puppeteer/SeleniumDriverManager.cs
+++ b/src/Uno.UITest.Puppeteer/SeleniumDriverManager.cs
@@ -102,8 +102,8 @@ namespace Uno.UITest.Selenium
 			public static EdgeDriver FromDriverPath(string driverPath, EdgeOptions options)
 				=> new EdgeDriver(driverPath, options);
 
-			private static Uri GetDriverLatestVersion(Version browserVersion) => new Uri($"https://msedgedriver.azureedge.net/LATEST_RELEASE_{browserVersion.Major}");
-			private static Uri GetDriverUri(Version browserVersion, string driverVersion) => new Uri($"https://msedgedriver.azureedge.net/{driverVersion}/edgedriver_win32.zip");
+			private static Uri GetDriverLatestVersion(Version browserVersion) => new Uri($"https://msedgedriver.microsoft.com/LATEST_RELEASE_{browserVersion.Major}");
+			private static Uri GetDriverUri(Version browserVersion, string driverVersion) => new Uri($"https://msedgedriver.microsoft.com/{driverVersion}/edgedriver_win32.zip");
 		}
 
 		private SeleniumDriverManager(string driverName)


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://github.com/unoplatform/Uno.UITest/issues/97

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix

## What is the current behavior?
HTTP 504 when trying to download msedge driver.

## What is the new behavior?
msedge driver is downloaded successfully.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)

## Other information

Internal Issue (If applicable):
